### PR TITLE
Command line interface

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -1,0 +1,38 @@
+======================
+Command line interface
+======================
+
+
+
+Top level commands
+------------------
+
+.. command-output:: oceanum --help
+
+
+Datamesh commands
+-----------------
+
+.. command-output:: oceanum datamesh --help
+
+
+Storage commands
+----------------
+
+.. command-output:: oceanum storage --help
+
+List content in storage system
+
+.. command-output:: oceanum storage ls --help
+
+Copy content from storage system
+
+.. command-output:: oceanum storage get --help
+
+Upload content to storage system
+
+.. command-output:: oceanum storage put --help
+
+Remove content from storage system (not implemented yet)
+
+.. command-output:: oceanum storage rm --help

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,6 +39,7 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinx.ext.napoleon",
     "sphinxcontrib.autodoc_pydantic",
+    "sphinxcontrib.programoutput",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,6 +14,7 @@ Documentation
 
 * :doc:`installation`
 * :doc:`usage`
+* :doc:`cli`
 * :doc:`api`
 * :doc:`about`
 
@@ -25,6 +26,7 @@ Documentation
 
    installation
    usage
+   cli
    api
    about
 

--- a/oceanum/cli.py
+++ b/oceanum/cli.py
@@ -1,7 +1,5 @@
 """Console script for oceanum library."""
 import click
-from pathlib import Path
-from aiohttp import ClientResponseError
 
 from oceanum.storage import filesystem
 

--- a/oceanum/cli.py
+++ b/oceanum/cli.py
@@ -1,16 +1,89 @@
-# -*- coding: utf-8 -*-
-
 """Console script for oceanum library."""
-import sys
 import click
+from aiohttp import ClientResponseError
+
+from oceanum.storage import FileSystem
 
 
-@click.command()
-def main(args=None):
-    """Console interface for oceanum."""
-    click.echo("Oceanum.io CLI. Just a stub at present.")
-    return 0
+def bytes_to_human(size):
+    """Convert bytes to human-readable format."""
+    if size < 1024:
+        return f"{size} B"
+    elif size < 1024 ** 2:
+        return f"{size / 1024:.1f} KiB"
+    elif size < 1024 ** 3:
+        return f"{size / 1024 ** 2:.1f} MiB"
+    elif size < 1024 ** 4:
+        return f"{size / 1024 ** 3:.1f} GiB"
+    else:
+        return f"{size / 1024 ** 4:.1f} TiB"
 
 
-if __name__ == "__main__":
-    sys.exit(main())  # pragma: no cover
+def item_to_long(item, human_readable=False):
+    """Convert item to long listing format."""
+    size = item["size"]
+    if human_readable:
+        size = bytes_to_human(size)
+    elif size == 0:
+        size = ""
+    modified = item["modified"] or ""
+    return f"{size:>10}  {modified:>32}  {item['name']}", item["size"]
+
+
+class Auth:
+    def __init__(self, datamesh_token=None):
+        self.datamesh_token = datamesh_token
+
+
+pass_auth = click.make_pass_decorator(Auth, ensure=True)
+
+
+@click.group()
+@click.option(
+    "-d",
+    "--datamesh_token",
+    help="Datamesh token, env DATAMESH_TOKEN by default",
+    envvar="DATAMESH_TOKEN",
+)
+@pass_auth
+def main(auth, datamesh_token):
+    auth.datamesh_token = datamesh_token
+
+
+@main.command()
+@click.option("-l", "--long", is_flag=True, help="Long listing format")
+@click.option("-h", "--human-readable", is_flag=True, help="Human readable sizes")
+@click.option("-r", "--recursive", is_flag=True, help="List subdirectories recursively")
+@click.argument("path", default="/")
+@pass_auth
+def ls(auth, path, long, human_readable, recursive):
+    """List contents in the oceanum storage (the root directory by default)."""
+    if recursive:
+        click.echo("Recursive option not yet implemented")
+    fs = FileSystem(auth.datamesh_token)
+    try:
+        items = fs.ls(path, detail=long)
+        if long:
+            sizes = 0
+            for item in items:
+                line, size = item_to_long(item, human_readable=human_readable)
+                sizes += size
+                click.echo(line)
+            click.echo(
+                f"TOTAL: {len(items)} objects, {sizes} bytes ({bytes_to_human(sizes)})"
+            )
+        else:
+            click.echo("\n".join(items))
+    except ClientResponseError:
+        click.echo(f"Path {path} not found or not authorised (check datamesh token)")
+
+
+
+@main.command()
+@click.argument("source")
+@click.argument("dest")
+@click.option("-r", "--recursive")
+@pass_auth
+def cp(auth, source, dest, recursive, datamesh_token):
+    """Copy SOURCE to DEST."""
+    pass

--- a/oceanum/cli.py
+++ b/oceanum/cli.py
@@ -149,7 +149,7 @@ def put(
 @click.argument("path")
 @pass_credentials
 def rm(credentials: Credentials, recursive: bool, path: str):
-    """Copy content from SOURCE to DEST."""
+    """Remove PATH."""
     filesystem.rm(
         path=path,
         recursive=recursive,

--- a/oceanum/cli.py
+++ b/oceanum/cli.py
@@ -40,14 +40,14 @@ pass_auth = click.make_pass_decorator(Auth, ensure=True)
 
 @click.group()
 @click.option(
-    "-d",
-    "--datamesh_token",
+    "-t",
+    "--token",
     help="Datamesh token, env DATAMESH_TOKEN by default",
     envvar="DATAMESH_TOKEN",
 )
 @pass_auth
-def main(auth, datamesh_token):
-    auth.datamesh_token = datamesh_token
+def main(auth, token):
+    auth.token = token
 
 
 @main.command()
@@ -58,7 +58,7 @@ def main(auth, datamesh_token):
 @pass_auth
 def ls(auth, path, long, human_readable, recursive):
     """List contents in the oceanum storage (the root directory by default)."""
-    fs = FileSystem(auth.datamesh_token)
+    fs = FileSystem(auth.token)
     try:
         maxdepth = None if recursive else 1
         items = fs.find(path, maxdepth=maxdepth, withdirs=True, detail=long)
@@ -82,6 +82,6 @@ def ls(auth, path, long, human_readable, recursive):
 @click.argument("dest")
 @click.option("-r", "--recursive")
 @pass_auth
-def cp(auth, source, dest, recursive, datamesh_token):
+def cp(auth, source, dest, recursive, token):
     """Copy SOURCE to DEST."""
     pass

--- a/oceanum/cli.py
+++ b/oceanum/cli.py
@@ -123,6 +123,40 @@ def get(
     )
 
 
+@storage.command()
+@click.option("-r", "--recursive", is_flag=True, help="Copy directories recursively")
+@click.argument("source")
+@click.argument("dest")
+@pass_credentials
+def put(
+    credentials: Credentials,
+    recursive: bool,
+    source: str,
+    dest: str,
+):
+    """Copy content from SOURCE to DEST."""
+    filesystem.put(
+        source=source,
+        dest=dest,
+        recursive=recursive,
+        token=credentials.datamesh_token,
+        service=credentials.storage_service,
+    )
+
+
+@storage.command()
+@click.option("-r", "--recursive", is_flag=True, help="Remove directories recursively")
+@click.argument("path")
+@pass_credentials
+def rm(credentials: Credentials, recursive: bool, path: str):
+    """Copy content from SOURCE to DEST."""
+    filesystem.rm(
+        path=path,
+        recursive=recursive,
+        token=credentials.datamesh_token,
+        service=credentials.storage_service,
+    )
+
 # =====================================================================================
 # Datamesh CLI
 # =====================================================================================

--- a/oceanum/cli.py
+++ b/oceanum/cli.py
@@ -31,8 +31,8 @@ def item_to_long(item, human_readable=False):
 
 
 class Auth:
-    def __init__(self, datamesh_token=None):
-        self.datamesh_token = datamesh_token
+    def __init__(self, token=None):
+        self.token = token
 
 
 pass_auth = click.make_pass_decorator(Auth, ensure=True)
@@ -47,10 +47,20 @@ pass_auth = click.make_pass_decorator(Auth, ensure=True)
 )
 @pass_auth
 def main(auth, token):
+    """Oceanum python commands."""
     auth.token = token
 
 
-@main.command()
+# =====================================================================================
+# Storage CLI
+# =====================================================================================
+@main.group()
+def storage():
+    """Oceanum storage commands."""
+    pass
+
+
+@storage.command()
 @click.option("-l", "--long", is_flag=True, help="Long listing format")
 @click.option("-h", "--human-readable", is_flag=True, help="Readable sizes with -l")
 @click.option("-r", "--recursive", is_flag=True, help="List subdirectories recursively")
@@ -77,7 +87,7 @@ def ls(auth, path, long, human_readable, recursive):
         click.echo(f"Path {path} not found or not authorised (check datamesh token)")
 
 
-@main.command()
+@storage.command()
 @click.argument("source")
 @click.argument("dest")
 @click.option("-r", "--recursive")
@@ -85,3 +95,13 @@ def ls(auth, path, long, human_readable, recursive):
 def cp(auth, source, dest, recursive, token):
     """Copy SOURCE to DEST."""
     pass
+
+
+# =====================================================================================
+# Datamesh CLI
+# =====================================================================================
+@main.group()
+def datamesh():
+    """Oceanum datamesh commands."""
+    pass
+

--- a/oceanum/cli.py
+++ b/oceanum/cli.py
@@ -52,20 +52,19 @@ def main(auth, datamesh_token):
 
 @main.command()
 @click.option("-l", "--long", is_flag=True, help="Long listing format")
-@click.option("-h", "--human-readable", is_flag=True, help="Human readable sizes")
+@click.option("-h", "--human-readable", is_flag=True, help="Readable sizes with -l")
 @click.option("-r", "--recursive", is_flag=True, help="List subdirectories recursively")
 @click.argument("path", default="/")
 @pass_auth
 def ls(auth, path, long, human_readable, recursive):
     """List contents in the oceanum storage (the root directory by default)."""
-    if recursive:
-        click.echo("Recursive option not yet implemented")
     fs = FileSystem(auth.datamesh_token)
     try:
-        items = fs.ls(path, detail=long)
+        maxdepth = None if recursive else 1
+        items = fs.find(path, maxdepth=maxdepth, withdirs=True, detail=long)
         if long:
             sizes = 0
-            for item in items:
+            for item in items.values():
                 line, size = item_to_long(item, human_readable=human_readable)
                 sizes += size
                 click.echo(line)
@@ -76,7 +75,6 @@ def ls(auth, path, long, human_readable, recursive):
             click.echo("\n".join(items))
     except ClientResponseError:
         click.echo(f"Path {path} not found or not authorised (check datamesh token)")
-
 
 
 @main.command()

--- a/oceanum/storage/filesystem.py
+++ b/oceanum/storage/filesystem.py
@@ -390,7 +390,7 @@ def get(
     token: str | None = None,
     service: str = DEFAULT_CONFIG["STORAGE_SERVICE"]
 ):
-    """Copy source to dest, or multiple sources to directory.
+    """Copy remote source to local dest, or multiple sources to directory.
 
     Parameters
     ----------
@@ -412,7 +412,6 @@ def get(
     - Directory dest defined with a trailing slash must exist, consistent with gsutil.
     - Non-existing file dest path is allowed, consistent with gsutil (all required
       intermediate directories are created).
-    - Source folder without trailing slash are copied 
 
     """
     fs = FileSystem(token=token, service=service)
@@ -441,3 +440,67 @@ def get(
     # Downloading
     fs.get(source, dest, recursive=recursive)
 
+
+def put(
+    source: str,
+    dest: str,
+    recursive: bool = False,
+    token: str | None = None,
+    service: str = DEFAULT_CONFIG["STORAGE_SERVICE"]
+):
+    """Copy local source to remote dest, or multiple sources to directory.
+
+    Parameters
+    ----------
+    source: str
+        Path to get.
+    dest: str
+        Destination path.
+    recursive: bool
+        Get directories recursively.
+    token: str
+        Oceanum datamesh token.
+    service: str
+        Oceanum storage service URL.
+
+    """
+    fs = FileSystem(token=token, service=service)
+    is_dest_dir = fs.isdir(dest)
+
+    # Deal with ClientOsError when trying to copy non-existing source
+    if not Path(source).exists():
+        raise FileNotFoundError(f"Source {source} not found")
+
+    # Ensure attempting to copy folder without recursive option does not fail silently
+    if Path(source).is_dir() and not recursive:
+        raise IsADirectoryError(f"--recursive is required to put directory {source}")
+
+    # Raise if trying to upload a folder into an existing file
+    if fs.exists(dest) and not is_dest_dir and Path(source).is_dir():
+        raise FileExistsError(f"Destination {dest} is an existing file")
+
+    # Downloading
+    fs.put(source, dest, recursive=recursive)
+
+
+def rm(
+    path: str,
+    recursive: bool = False,
+    token: str | None = None,
+    service: str = DEFAULT_CONFIG["STORAGE_SERVICE"]
+):
+    """Copy local source to remote dest, or multiple sources to directory.
+
+    Parameters
+    ----------
+    path: str
+        Path to remove.
+    recursive: bool
+        Remove directories recursively.
+    token: str
+        Oceanum datamesh token.
+    service: str
+        Oceanum storage service URL.
+
+    """
+    raise NotImplementedError("rm not implemented yet")

--- a/oceanum/storage/filesystem.py
+++ b/oceanum/storage/filesystem.py
@@ -8,6 +8,7 @@ import random
 from copy import copy
 from urllib.parse import urlparse
 from decorator import decorator
+from pathlib import Path
 
 import aiohttp
 import fsspec
@@ -342,3 +343,101 @@ class FileSystem(AsyncFileSystem):
     def ukey(self, path):
         """Unique identifier"""
         return tokenize(path)
+
+
+def ls(
+    path: str,
+    recursive: bool,
+    detail: bool = False,
+    token: str | None = None,
+    service: str = DEFAULT_CONFIG["STORAGE_SERVICE"]
+):
+    """List contents in the oceanum storage (the root directory by default).
+
+    Parameters
+    ----------
+    path: str
+        Path to list.
+    recursive: bool
+        List subdirectories recursively.
+    detail: bool
+        Return detailed information about each content.
+    token: str
+        Oceanum datamesh token.
+    service: str
+        Oceanum storage service URL.
+
+    Returns
+    -------
+    contents: list | dict
+        List of contents or dictionary with detailed information about each content.
+
+    """
+    fs = FileSystem(token=token, service=service)
+    try:
+        maxdepth = None if recursive else 1
+        return fs.find(path, maxdepth=maxdepth, withdirs=True, detail=detail)
+    except aiohttp.client_exceptions.ClientError as err:
+        raise aiohttp.client_exceptions.ClientError(
+            f"Path {path} not found or not authorised (check datamesh token)"
+        ) from err
+
+
+def get(
+    source: str,
+    dest: str,
+    recursive: bool = False,
+    token: str | None = None,
+    service: str = DEFAULT_CONFIG["STORAGE_SERVICE"]
+):
+    """Copy source to dest, or multiple sources to directory.
+
+    Parameters
+    ----------
+    source: str
+        Path to get.
+    dest: str
+        Destination path.
+    recursive: bool
+        Get directories recursively.
+    overwrite: bool
+        Overwrite existing destination.
+    token: str
+        Oceanum datamesh token.
+    service: str
+        Oceanum storage service URL.
+
+    Notes
+    -----
+    - Directory dest defined with a trailing slash must exist, consistent with gsutil.
+    - Non-existing file dest path is allowed, consistent with gsutil (all required
+      intermediate directories are created).
+    - Source folder without trailing slash are copied 
+
+    """
+    fs = FileSystem(token=token, service=service)
+    is_source_dir = fs.isdir(source)
+
+    # Ensure attempting to copy folder without recursive option does not fail silently
+    if is_source_dir and not recursive:
+        raise IsADirectoryError(f"--recursive is required to get directory {source}")
+
+    # Deal with mimetype error when trying to copy file with recursive option
+    if not is_source_dir and recursive:
+        raise NotADirectoryError(f"Source {source} is a file, do not use --recursive")
+
+    # Prevent from downloading into a folder that does not exist
+    if not Path(dest).is_dir() and dest.endswith(os.path.sep):
+        raise FileNotFoundError(f"Destination directory {dest} not found")
+
+    # Expand destination file name to avoid IsADirectoryError
+    if not is_source_dir and Path(dest).is_dir():
+        dest = str(Path(dest) / Path(source).name)
+
+    # Expand destination folder name if different than source's to keep path structure
+    if is_source_dir and Path(dest) != Path(source):
+        dest = str(Path(dest) / Path(source).name)
+
+    # Downloading
+    fs.get(source, dest, recursive=recursive)
+

--- a/oceanum/storage/filesystem.py
+++ b/oceanum/storage/filesystem.py
@@ -489,7 +489,7 @@ def rm(
     token: str | None = None,
     service: str = DEFAULT_CONFIG["STORAGE_SERVICE"]
 ):
-    """Copy local source to remote dest, or multiple sources to directory.
+    """Remove path file or directory.
 
     Parameters
     ----------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dynamic = ["version"]
 [project.optional-dependencies]
 test = [
   "pytest",
+  "pytest-env",
 ]
 extra = [
     "xarray_video",
@@ -82,3 +83,10 @@ exclude = ["tests", "docs"]
 
 [tool.distutils.bdist_wheel]
 universal = true
+
+[tool.pytest.ini_options]
+required_plugins = "pytest-env"
+
+env = [
+  "DATAMESH_TOKEN = aa54ff999abf474c0c1584fb6e97134249c3e437",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ universal = true
 
 [tool.pytest.ini_options]
 required_plugins = "pytest-env"
-
 env = [
   "DATAMESH_TOKEN = aa54ff999abf474c0c1584fb6e97134249c3e437",
+  "STORAGE_SERVICE = https://storage.oceanum.io",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ docs = [
   "autodoc-pydantic",
   "pydata-sphinx-theme",
   "sphinx",
+  "sphinxcontrib-programoutput",
 ]
 
 [project.urls]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,43 +16,43 @@ def runner():
 # =====================================================================================
 # oceanum storage ls
 # =====================================================================================
-# def test_main(runner):
-#     result = runner.invoke(cli.main)
-#     assert result.exit_code == 0
-#     assert "main" in result.output
+def test_main(runner):
+    result = runner.invoke(cli.main)
+    assert result.exit_code == 0
+    assert "main" in result.output
 
 
-# def test_storage(runner):
-#     result = runner.invoke(cli.storage, ["-s", "https://storage.oceanum.io", "--help"])
-#     assert result.exit_code == 0
-#     assert "Oceanum storage commands" in result.output
+def test_storage(runner):
+    result = runner.invoke(cli.storage, ["-s", "https://storage.oceanum.io", "--help"])
+    assert result.exit_code == 0
+    assert "Oceanum storage commands" in result.output
 
 
-# def test_storage_ls(runner):
-#     result = runner.invoke(cli.storage, ["ls", "file_test_dir"])
-#     assert result.exit_code == 0
-#     assert "file_test_dir/test_file" in result.output
+def test_storage_ls(runner):
+    result = runner.invoke(cli.storage, ["ls", "file_test_dir"])
+    assert result.exit_code == 0
+    assert "file_test_dir/test_file" in result.output
 
 
-# def test_storage_ls_long(runner):
-#     result = runner.invoke(cli.storage, ["ls", "-l", "file_test_dir"])
-#     assert result.exit_code == 0
-#     assert pd.to_datetime(result.output.split()[1])
-#     assert "TOTAL" in result.output
+def test_storage_ls_long(runner):
+    result = runner.invoke(cli.storage, ["ls", "-l", "file_test_dir"])
+    assert result.exit_code == 0
+    assert pd.to_datetime(result.output.split()[1])
+    assert "TOTAL" in result.output
 
 
-# def test_storage_ls_human_readable(runner):
-#     result = runner.invoke(cli.storage, ["ls", "-l", "file_test_dir"])
-#     size_bytes = result.output.split()[0]
-#     result = runner.invoke(cli.storage, ["ls", "-lh", "file_test_dir"])
-#     size_human = " ".join(result.output.split()[0:2])
-#     size_human == cli.bytes_to_human(float(size_bytes))
+def test_storage_ls_human_readable(runner):
+    result = runner.invoke(cli.storage, ["ls", "-l", "file_test_dir"])
+    size_bytes = result.output.split()[0]
+    result = runner.invoke(cli.storage, ["ls", "-lh", "file_test_dir"])
+    size_human = " ".join(result.output.split()[0:2])
+    size_human == cli.bytes_to_human(float(size_bytes))
 
 
-# def test_storage_ls_recursive(runner):
-#     # TODO: Create netsted test files so this option can be tested
-#     result = runner.invoke(cli.storage, ["ls", "-r"])
-#     assert result.exit_code == 0
+def test_storage_ls_recursive(runner):
+    # TODO: Create netsted test files so this option can be tested
+    result = runner.invoke(cli.storage, ["ls", "-r"])
+    assert result.exit_code == 0
 
 
 # =====================================================================================
@@ -125,12 +125,42 @@ def test_storage_get_folder_existing_root_folder_dest(runner, tmp_path):
     assert (dest / source).is_dir()
 
 
-# def test_storage_get_folder_existing_root_folder_dest(runner, tmp_path):
-#     source = "test_folder"
-#     dest = tmp_path
-#     result = runner.invoke(cli.storage, ["get", "-r", source, str(dest)])
-#     assert result.exit_code == 0
-#     assert (dest / source).is_dir()
+# =====================================================================================
+# oceanum storage put
+# =====================================================================================
+# TODO: Ensure objects created here are deleted
+
+def test_storage_put_not_found_raises(runner):
+    source = str(uuid4())
+    result = runner.invoke(cli.storage, ["put", source, "/test_upload"])
+    assert isinstance(result.exception, FileNotFoundError)
+
+
+def test_storage_put_file(runner, tmp_path):
+    source = tmp_path / "test_file_put"
+    source.touch()
+    dest = "/test_upload/"
+    result = runner.invoke(cli.storage, ["put", str(source), dest])
+    assert result.exit_code == 0
+
+
+def test_storage_get_folder_without_recursive_fails(runner, tmp_path):
+    source = tmp_path / "test_dir_put"
+    source.mkdir()
+    dest = Path("test_upload") / source.name
+    result = runner.invoke(cli.storage, ["put", str(source), str(dest)])
+    assert isinstance(result.exception, IsADirectoryError)
+
+
+def test_storage_put_folder_into_existing_file_fails(runner, tmp_path):
+    dest = "/test_upload/test_file_put"
+    source = tmp_path / "test_file_put"
+    source.touch()
+    result = runner.invoke(cli.storage, ["put", str(source), dest])
+    source = tmp_path / "test_dir_put"
+    source.mkdir()
+    result = runner.invoke(cli.storage, ["put", "-r", str(source), dest])
+    assert isinstance(result.exception, FileExistsError)
 
 
 # def test_datamesh(runner):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,28 +17,40 @@ def test_main(runner):
     assert "main" in result.output
 
 
-def test_ls(runner):
-    result = runner.invoke(cli.main, ["ls", "file_test_dir"])
+def test_storage(runner):
+    result = runner.invoke(cli.storage)
+    assert result.exit_code == 0
+    assert "Oceanum storage commands" in result.output
+
+
+def test_storage_ls(runner):
+    result = runner.invoke(cli.storage, ["ls", "file_test_dir"])
     assert result.exit_code == 0
     assert "file_test_dir/test_file" in result.output
 
 
-def test_ls_long(runner):
-    result = runner.invoke(cli.main, ["ls", "-l", "file_test_dir"])
+def test_storage_ls_long(runner):
+    result = runner.invoke(cli.storage, ["ls", "-l", "file_test_dir"])
     assert result.exit_code == 0
     assert pd.to_datetime(result.output.split()[1])
     assert "TOTAL" in result.output
 
 
-def test_ls_human_readable(runner):
-    result = runner.invoke(cli.main, ["ls", "-l", "file_test_dir"])
+def test_storage_ls_human_readable(runner):
+    result = runner.invoke(cli.storage, ["ls", "-l", "file_test_dir"])
     size_bytes = result.output.split()[0]
-    result = runner.invoke(cli.main, ["ls", "-lh", "file_test_dir"])
+    result = runner.invoke(cli.storage, ["ls", "-lh", "file_test_dir"])
     size_human = " ".join(result.output.split()[0:2])
     size_human == cli.bytes_to_human(float(size_bytes))
 
 
-def test_ls_recursive(runner):
+def test_storage_ls_recursive(runner):
     # TODO: Create netsted test files so this option can be tested
-    result = runner.invoke(cli.main, ["ls", "-r"])
+    result = runner.invoke(cli.storage, ["ls", "-r"])
     assert result.exit_code == 0
+
+
+def test_datamesh(runner):
+    result = runner.invoke(cli.datamesh)
+    assert result.exit_code == 0
+    assert "Oceanum datamesh commands" in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,7 @@
 import pytest
+from uuid import uuid4
 import pandas as pd
+from pathlib import Path
 from click.testing import CliRunner
 
 from oceanum import cli
@@ -11,46 +13,127 @@ def runner():
     yield instance
 
 
-def test_main(runner):
-    result = runner.invoke(cli.main)
+# =====================================================================================
+# oceanum storage ls
+# =====================================================================================
+# def test_main(runner):
+#     result = runner.invoke(cli.main)
+#     assert result.exit_code == 0
+#     assert "main" in result.output
+
+
+# def test_storage(runner):
+#     result = runner.invoke(cli.storage, ["-s", "https://storage.oceanum.io", "--help"])
+#     assert result.exit_code == 0
+#     assert "Oceanum storage commands" in result.output
+
+
+# def test_storage_ls(runner):
+#     result = runner.invoke(cli.storage, ["ls", "file_test_dir"])
+#     assert result.exit_code == 0
+#     assert "file_test_dir/test_file" in result.output
+
+
+# def test_storage_ls_long(runner):
+#     result = runner.invoke(cli.storage, ["ls", "-l", "file_test_dir"])
+#     assert result.exit_code == 0
+#     assert pd.to_datetime(result.output.split()[1])
+#     assert "TOTAL" in result.output
+
+
+# def test_storage_ls_human_readable(runner):
+#     result = runner.invoke(cli.storage, ["ls", "-l", "file_test_dir"])
+#     size_bytes = result.output.split()[0]
+#     result = runner.invoke(cli.storage, ["ls", "-lh", "file_test_dir"])
+#     size_human = " ".join(result.output.split()[0:2])
+#     size_human == cli.bytes_to_human(float(size_bytes))
+
+
+# def test_storage_ls_recursive(runner):
+#     # TODO: Create netsted test files so this option can be tested
+#     result = runner.invoke(cli.storage, ["ls", "-r"])
+#     assert result.exit_code == 0
+
+
+# =====================================================================================
+# oceanum storage get
+# =====================================================================================
+def test_storage_get_not_found_raises(runner, tmp_path):
+    source = str(uuid4())
+    dest = str(tmp_path / source)
+    result = runner.invoke(cli.storage, ["get", source, dest])
+    assert isinstance(result.exception, FileNotFoundError)
+
+
+def test_storage_get_file_into_file_dest(runner, tmp_path):
+    source = "test_object"
+    dest = tmp_path / source
+    result = runner.invoke(cli.storage, ["get", source, str(dest)])
     assert result.exit_code == 0
-    assert "main" in result.output
+    assert dest.is_file()
 
 
-def test_storage(runner):
-    result = runner.invoke(cli.storage, ["-s", "https://storage.oceanum.io", "--help"])
+def test_storage_get_file_into_existing_folder(runner, tmp_path):
+    source = "test_object"
+    result = runner.invoke(cli.storage, ["get", source, str(tmp_path)])
     assert result.exit_code == 0
-    assert "Oceanum storage commands" in result.output
+    assert (tmp_path / source).is_file()
 
 
-def test_storage_ls(runner):
-    result = runner.invoke(cli.storage, ["ls", "file_test_dir"])
+def test_storage_get_file_into_nonexisting_folder_fails(runner, tmp_path):
+    source = "test_object"
+    dest = str(tmp_path / "nonexisting_folder") + "/"
+    result = runner.invoke(cli.storage, ["get", source, dest])
+    assert isinstance(result.exception, FileNotFoundError)
+
+
+def test_storage_get_file_into_file_within_nonexisting_folder_works(runner, tmp_path):
+    source = "test_object"
+    dest = tmp_path / "nonexisting_folder" / source
+    result = runner.invoke(cli.storage, ["get", source, str(dest)])
     assert result.exit_code == 0
-    assert "file_test_dir/test_file" in result.output
+    assert dest.is_file()
 
 
-def test_storage_ls_long(runner):
-    result = runner.invoke(cli.storage, ["ls", "-l", "file_test_dir"])
+def test_storage_get_file_with_recursive_fails(runner, tmp_path):
+    source = "test_object"
+    dest = tmp_path / source
+    result = runner.invoke(cli.storage, ["get", "-r", source, str(dest)])
+    assert isinstance(result.exception, NotADirectoryError)
+
+
+def test_storage_get_folder_without_recursive_fails(runner, tmp_path):
+    source = "test_folder"
+    dest = tmp_path / source
+    result = runner.invoke(cli.storage, ["get", source, str(dest)])
+    assert isinstance(result.exception, IsADirectoryError)
+
+
+def test_storage_get_folder_into_full_folder_dest(runner, tmp_path):
+    source = "test_folder"
+    dest = tmp_path / source
+    result = runner.invoke(cli.storage, ["get", "-r", source, str(dest)])
     assert result.exit_code == 0
-    assert pd.to_datetime(result.output.split()[1])
-    assert "TOTAL" in result.output
+    assert dest.is_dir()
 
 
-def test_storage_ls_human_readable(runner):
-    result = runner.invoke(cli.storage, ["ls", "-l", "file_test_dir"])
-    size_bytes = result.output.split()[0]
-    result = runner.invoke(cli.storage, ["ls", "-lh", "file_test_dir"])
-    size_human = " ".join(result.output.split()[0:2])
-    size_human == cli.bytes_to_human(float(size_bytes))
-
-
-def test_storage_ls_recursive(runner):
-    # TODO: Create netsted test files so this option can be tested
-    result = runner.invoke(cli.storage, ["ls", "-r"])
+def test_storage_get_folder_existing_root_folder_dest(runner, tmp_path):
+    source = "test_folder"
+    dest = tmp_path
+    result = runner.invoke(cli.storage, ["get", "-r", source, str(dest)])
     assert result.exit_code == 0
+    assert (dest / source).is_dir()
 
 
-def test_datamesh(runner):
-    result = runner.invoke(cli.datamesh)
-    assert result.exit_code == 0
-    assert "Oceanum datamesh commands" in result.output
+# def test_storage_get_folder_existing_root_folder_dest(runner, tmp_path):
+#     source = "test_folder"
+#     dest = tmp_path
+#     result = runner.invoke(cli.storage, ["get", "-r", source, str(dest)])
+#     assert result.exit_code == 0
+#     assert (dest / source).is_dir()
+
+
+# def test_datamesh(runner):
+#     result = runner.invoke(cli.datamesh)
+#     assert result.exit_code == 0
+#     assert "Oceanum datamesh commands" in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,44 @@
+import pytest
+import pandas as pd
+from click.testing import CliRunner
+
+from oceanum import cli
+
+
+@pytest.fixture(scope="module")
+def runner():
+    instance = CliRunner()
+    yield instance
+
+
+def test_main(runner):
+    result = runner.invoke(cli.main)
+    assert result.exit_code == 0
+    assert "main" in result.output
+
+
+def test_ls(runner):
+    result = runner.invoke(cli.main, ["ls", "file_test_dir"])
+    assert result.exit_code == 0
+    assert "file_test_dir/test_file" in result.output
+
+
+def test_ls_long(runner):
+    result = runner.invoke(cli.main, ["ls", "-l", "file_test_dir"])
+    assert result.exit_code == 0
+    assert pd.to_datetime(result.output.split()[1])
+    assert "TOTAL" in result.output
+
+
+def test_ls_human_readable(runner):
+    result = runner.invoke(cli.main, ["ls", "-l", "file_test_dir"])
+    size_bytes = result.output.split()[0]
+    result = runner.invoke(cli.main, ["ls", "-lh", "file_test_dir"])
+    size_human = " ".join(result.output.split()[0:2])
+    size_human == cli.bytes_to_human(float(size_bytes))
+
+
+def test_ls_recursive(runner):
+    # TODO: Create netsted test files so this option can be tested
+    result = runner.invoke(cli.main, ["ls", "-r"])
+    assert result.exit_code == 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -18,7 +18,7 @@ def test_main(runner):
 
 
 def test_storage(runner):
-    result = runner.invoke(cli.storage)
+    result = runner.invoke(cli.storage, ["-s", "https://storage.oceanum.io", "--help"])
     assert result.exit_code == 0
     assert "Oceanum storage commands" in result.output
 


### PR DESCRIPTION
First cut for a oceanum-python command line interface. Storage commands inspired on behaviour from `gsutil`.

Code structure:
- Oceanum top-level CLI with nested commands corresponding to the different subpackages (datamesh, storage, etc).
- CLI currently implemented for the `storage` subpackage.
- Wrapper functions in the `oceanum.storage.filesystem` module (`ls`, `get`, `put`, etc).
- CLI functions in `oceanum.cli` module.

Usage examples:

```
oceanum storage ls
oceanum -t ${DATAMESH_TOKEN} storage -s ${STORAGE_SYSTEM} ls
oceanum -t ${DATAMESH_TOKEN} storage get SOURCE DEST

```

Some preliminary docs added in the `cli` toctree
