### PR TITLE
Allow ls kwargs

### DIFF
--- a/oceanum/storage/filesystem.py
+++ b/oceanum/storage/filesystem.py
@@ -136,7 +136,6 @@ class FileSystem(AsyncFileSystem):
         file_prefix=None,
         match_glob=None,
         limit=None,
-        **kwargs
     ):
         logger.debug(path)
         session = await self.set_session()
@@ -165,7 +164,6 @@ class FileSystem(AsyncFileSystem):
                         file_prefix=file_prefix,
                         match_glob=match_glob,
                         limit=limit,
-                        **kwargs
                     )
             listing = await r.json()
             if not listing:

--- a/oceanum/storage/filesystem.py
+++ b/oceanum/storage/filesystem.py
@@ -148,13 +148,12 @@ class FileSystem(AsyncFileSystem):
             params["file_prefix"] = file_prefix
         if match_glob:
             params["match_glob"] = match_glob
-
+        
         async with session.get(self._base_url + spath, params=params or None) as r:
             try:
                 self._raise_not_found_for_status(r, path)
-            except (
-                FileNotFoundError
-            ):  # The storage endpoint enforces trailing slash for directories, so test for that
+            except FileNotFoundError:
+                # The storage endpoint enforces trailing slash for directories, so test for that
                 if path.endswith("/"):
                     raise FileNotFoundError(path)
                 else:

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -58,6 +58,31 @@ def test_ls(fs, dummy_files):
     paths = list(fs.walk(REMOTE_PATH))
     assert len(paths) == 2
 
+def test_ls_file_prefix(fs, dummy_files):
+    test_folder = f'{REMOTE_PATH}/test'
+    fs.mkdirs(test_folder, exist_ok=True)
+    fs.put(dummy_files.name, test_folder, recursive=True)
+    files = fs.ls(test_folder, file_prefix="file1")
+    assert len(files) == 1
+    assert files[0]["name"] == "test_storage/test/file1.txt"
+
+def test_ls_glob(fs, dummy_files):
+    test_folder = f'{REMOTE_PATH}/test'
+    fs.mkdirs(test_folder, exist_ok=True)
+    fs.put(dummy_files.name, test_folder, recursive=True)
+    files = fs.ls(test_folder, match_glob="**/*2.txt")
+    assert len(files) == 1
+    assert files[0]["name"] == "test_storage/test/file2.txt"
+
+def test_ls_limit(fs, dummy_files):
+    test_folder = f'{REMOTE_PATH}/test'
+    fs.mkdirs(test_folder, exist_ok=True)
+    fs.put(dummy_files.name, test_folder, recursive=True)
+    # Something is off with limit
+    # At the storage API level, it returns 1 file when limit=2
+    files = fs.ls(test_folder, limit=2)
+    assert len(files) == 1
+    assert files[0]["name"] == "test_storage/test/file1.txt"
 
 def test_get(fs, dummy_files):
     fs.mkdirs(REMOTE_PATH, exist_ok=True)

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -48,15 +48,12 @@ def test_dir_not_found(fs):
 
 
 def test_ls(fs, dummy_files):
-    fs.mkdirs(REMOTE_PATH, exist_ok=True)
-    fs.put(os.path.join(dummy_files.name, "test"), REMOTE_PATH, recursive=True)
-
-    files = fs.ls(REMOTE_PATH)
-    assert len(files) == 1
-    assert files[0]["type"] == "directory"
-
-    paths = list(fs.walk(REMOTE_PATH))
-    assert len(paths) == 2
+    rand_dir = os.path.join(REMOTE_PATH,os.path.basename(tempfile.TemporaryDirectory().name))
+    fs.mkdirs(rand_dir, exist_ok=True)
+    fs.put(os.path.join(dummy_files.name, 'test'), rand_dir, recursive=True)
+    files = fs.ls(os.path.join(rand_dir, 'test'))
+    assert os.path.join(rand_dir, 'test', 'file1.txt') in [f["name"] for f in files]
+    assert os.path.join(rand_dir, 'test', 'file2.txt') in [f["name"] for f in files]
 
 def test_ls_file_prefix(fs, dummy_files):
     test_folder = f'{REMOTE_PATH}/test'


### PR DESCRIPTION
Implements listing parameters, such as `file_prefix`, `match_glob` and `limit`. This allows much faster listing when working with bucket folders with many files.