### PR TITLE
Allow get_catalog ignore items that raise ValidationError

### DIFF
--- a/src/oceanum/datamesh/catalog.py
+++ b/src/oceanum/datamesh/catalog.py
@@ -1,5 +1,9 @@
+import logging
+from pydantic import ValidationError
 from geojson_pydantic import Feature, FeatureCollection
 from .datasource import Datasource
+
+logger = logging.getLogger(__name__)
 
 
 class Catalog(object):
@@ -27,9 +31,15 @@ class Catalog(object):
         if item in self._ids:
             index = self._ids.index(item)
             feature = self._geojson.features[index]
-            return Datasource(
-                id=feature.id, geom=feature.geometry.model_dump(), **feature.properties
-            )
+            try:
+                return Datasource(
+                    id=feature.id,
+                    geom=feature.geometry.model_dump(),
+                    **feature.properties
+                )
+            except ValidationError:
+                logger.warning(f"Failed to get datasource {item} in catalog")
+                return None
         else:
             raise IndexError(f"Datasource {item} not in catalog")
 

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -2,21 +2,68 @@
 # -*- coding: utf-8 -*-
 
 """Tests for `oceanum` package."""
+from pathlib import Path
+import json
 import os
 import pytest
 import shapely
-
+import xarray as xr
+from uuid import uuid4
 from click.testing import CliRunner
 
 from oceanum.datamesh import Connector, Datasource
 from oceanum.datamesh.query import GeoFilter, TimeFilter
+from oceanum.datamesh.utils import retried_request
 from oceanum import cli
+
+
+HERE = Path(__file__).parent
 
 
 @pytest.fixture
 def conn():
     """Connection fixture"""
     return Connector(os.environ["DATAMESH_TOKEN"])
+
+
+@pytest.fixture
+def dataset():
+    ds = xr.open_dataset(HERE / "data/grid_data_1.nc")
+    return ds.isel(longitude=slice(0, 2), latitude=slice(0, 2), time=slice(0, 2))
+
+
+def test_catalog_ignore_broken(conn, dataset):
+    tag = str(uuid4())[:8]
+    datasource_id = f"test-dataset-catalog-{tag}"
+    try:
+        x0, x1 = dataset.longitude.values[[0, -1]]
+        y0, y1 = dataset.latitude.values[[0, -1]]
+        conn.write_datasource(
+            datasource_id,
+            dataset,
+            overwrite=True,
+            geom=shapely.geometry.box(x0, y0, x1, y1),
+            tags=[tag, "test", "dataset", "catalog"],
+        )
+        # Corrupt the metadata
+        ds = conn.get_datasource(datasource_id)
+        data = json.loads(
+            ds.model_dump_json(by_alias=True, warnings=False).encode("utf-8", "ignore")
+        )
+        data["coordinates"] = {"dummy_key": "dummy_val"}
+        data = json.dumps(data).encode("utf-8", "ignore")
+        headers = {**conn._auth_headers, "Content-Type": "application/json"}
+        resp = retried_request(
+            f"{conn._proto}://{conn._host}/datasource/{datasource_id}/",
+            method="PATCH",
+            data=data,
+            headers=headers,
+        )
+        # The catalog should return None for this datasource
+        cat = conn.get_catalog(search=datasource_id)
+        assert None in list(cat)
+    finally:
+        conn.delete_datasource(datasource_id)
 
 
 def test_catalog_search(conn):


### PR DESCRIPTION
Allow get_catalog ignore items that raise ValidationError. Currently, if any datasource is corrupted and causes a validation error when instantiating, get_datasource will return a broken catalog that cannot be iterated over. This pull request makes it ignore failing items, and logs them as a warning.