### PR TITLE
Improve GeoFilter input flexibility and warn on unknown Query parameters

### DIFF
--- a/src/oceanum/datamesh/query.py
+++ b/src/oceanum/datamesh/query.py
@@ -1,4 +1,6 @@
 import datetime
+import difflib
+import warnings
 import pandas as pd
 import numpy as np
 import shapely
@@ -357,6 +359,26 @@ class Query(BaseModel):
     """
     Datamesh query
     """
+
+    def __init__(self, **data):
+        field_names = set(Query.model_fields.keys())
+        extra_keys = set(data.keys()) - field_names
+        for key in extra_keys:
+            close = difflib.get_close_matches(key, field_names, n=1, cutoff=0.6)
+            if close:
+                warnings.warn(
+                    f"Query received unknown parameter '{key}' - did you mean '{close[0]}'?",
+                    UserWarning,
+                    stacklevel=2,
+                )
+            else:
+                warnings.warn(
+                    f"Query received unknown parameter '{key}' - it will be ignored. "
+                    f"Valid parameters: {', '.join(sorted(field_names))}",
+                    UserWarning,
+                    stacklevel=2,
+                )
+        super().__init__(**data)
 
     datasource: str = Field(
         title="The id of the datasource",

--- a/src/oceanum/datamesh/query.py
+++ b/src/oceanum/datamesh/query.py
@@ -207,7 +207,7 @@ class GeoFilter(BaseModel):
     @field_validator("geom", mode="before")
     @classmethod
     def validate_geom(cls, v):
-        if isinstance(v, list):
+        if isinstance(v, (list, tuple)):
             if len(v) != 4:
                 raise ValueError(
                     "bbox must be a list of length 4: [x_min,y_min,x_max,y_max]"

--- a/src/oceanum/datamesh/query.py
+++ b/src/oceanum/datamesh/query.py
@@ -207,7 +207,8 @@ class GeoFilter(BaseModel):
     @field_validator("geom", mode="before")
     @classmethod
     def validate_geom(cls, v):
-        if isinstance(v, (list, tuple)):
+        if isinstance(v, (list, tuple, np.ndarray)):
+            v = list(v)
             if len(v) != 4:
                 raise ValueError(
                     "bbox must be a list of length 4: [x_min,y_min,x_max,y_max]"

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 import pytest
 import datetime
 import shapely
@@ -96,3 +97,32 @@ def test_stage_resp():
         container="dataset",
         sig="efg"
     )
+
+
+def test_query_unknown_param_close_match():
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        q = Query(datasource="test", tiemfilter=None)
+    assert len(w) == 1
+    assert "tiemfilter" in str(w[0].message)
+    assert "timefilter" in str(w[0].message)
+    assert "did you mean" in str(w[0].message).lower()
+    # Ensure the misspelled param is not in the serialized output
+    assert "tiemfilter" not in q.model_dump()
+
+
+def test_query_unknown_param_no_match():
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        q = Query(datasource="test", zzzzz="bar")
+    assert len(w) == 1
+    assert "zzzzz" in str(w[0].message)
+    assert "will be ignored" in str(w[0].message).lower()
+    assert "zzzzz" not in q.model_dump()
+
+
+def test_query_valid_params_no_warning():
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        q = Query(datasource="test", variables=["a", "b"])
+    assert len(w) == 0


### PR DESCRIPTION
## Summary

- Allow `GeoFilter.geom` to accept tuples and numpy arrays (in addition to lists) for bbox input, coercing to list to avoid serialization issues
- Warn users when an unknown/misspelled parameter is passed to `Query`, with a "did you mean?" suggestion for close matches (e.g. `tiemfilter` → `timefilter`); unknown params are still silently dropped from serialization, so this is non-breaking
- Add pytest tests for the new warning behaviour

## Test plan

- [x] `pytest tests/test_query.py` — all query tests pass
- [x] `pytest tests/test_query.py::test_query_unknown_param_close_match` — warns with "did you mean?" for close matches
- [x] `pytest tests/test_query.py::test_query_unknown_param_no_match` — warns with "will be ignored" for unrecognised params
- [x] `pytest tests/test_query.py::test_query_valid_params_no_warning` — no warning for valid params
- [x] Full CI suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)