### PR TITLE
fix(datamesh): document and test ISO8601-2 negative periods in timefilter

### DIFF
--- a/src/oceanum/__init__.py
+++ b/src/oceanum/__init__.py
@@ -4,7 +4,7 @@
 
 __author__ = """Oceanum Developers"""
 __email__ = "developers@oceanum.science"
-__version__ = "1.0.16"
+__version__ = "1.0.17"
 
 
 # Suppress tracebacks in an ipython environment

--- a/src/oceanum/datamesh/query.py
+++ b/src/oceanum/datamesh/query.py
@@ -72,6 +72,15 @@ Timestamp = Annotated[
 
 
 def parse_timedelta(v):
+    """Parse a time period into a python timedelta.
+
+    Accepts a python ``timedelta``, numpy ``timedelta64``, pandas ``Timedelta``
+    or an ISO8601 duration string. Following the ISO8601-2 convention, a leading
+    minus sign denotes a negative period (e.g. ``"-P7D"``), and negative
+    ``timedelta``/``timedelta64`` values are likewise preserved. A period is
+    resolved relative to the current time: a positive period resolves to a time
+    *after* now and a negative period to a time *before* now.
+    """
     if v is None:
         return None
     if not (
@@ -95,7 +104,13 @@ Timedelta = Annotated[
     Field(
         default=None,
         title="Timedelta",
-        description="Timedelta as python timedelta, numpy timedelta64 or pandas Timedelta",
+        description=(
+            "Time period as a python timedelta, numpy timedelta64, pandas "
+            "Timedelta or ISO8601 duration string. Negative periods are "
+            "supported following the ISO8601-2 convention (e.g. '-P7D'): a "
+            "positive period resolves to a time after the current time and a "
+            "negative period to a time before the current time."
+        ),
     ),
     BeforeValidator(parse_timedelta),
     WithJsonSchema({"type": "string", "format": "time-period"}),
@@ -257,7 +272,15 @@ class LevelFilter(BaseModel):
 
 class TimeFilter(BaseModel):
     """TimeFilter class
-    Describes a temporal subset or interpolation
+    Describes a temporal subset or interpolation.
+
+    Each value in ``times`` may be an absolute time (Timestamp) or a period
+    relative to the current time (Timedelta). Periods follow the ISO8601-2
+    convention where a leading minus sign denotes a negative period: a positive
+    period (e.g. ``"P7D"``) resolves to a time *after* now and a negative period
+    (e.g. ``"-P7D"``) to a time *before* now. This applies equally to the start
+    and end of a range, so e.g. ``times=["-P7D", "P1D"]`` selects from 7 days
+    before now to 1 day after now.
     """
 
     type: TimeFilterType = Field(
@@ -273,6 +296,10 @@ class TimeFilter(BaseModel):
     times: List[Union[Timestamp, Timedelta, None]] = Field(
         title="Selection times",
         description="""
+            Absolute times (Timestamp) or periods relative to the current time
+            (Timedelta). Periods use the ISO8601-2 convention: a positive period
+            (e.g. 'P7D') resolves after the current time, a negative period
+            (e.g. '-P7D') before it. This applies to both timestart and tend.
             - For type='range', [timestart, tend].
         """,
     )
@@ -409,7 +436,7 @@ class Query(BaseModel):
     id: Optional[str] = Field(title="Unique ID of this query", default=None)
 
     def __bool__(self):
-        for k,v in self.__dict__.items():
+        for k, v in self.__dict__.items():
             if not k in ["datasource", "description", "id"] and v:
                 return True
         return False

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,4 +1,5 @@
 import os
+import json
 import pytest
 import datetime
 import shapely
@@ -25,20 +26,50 @@ def test_query_timefilter():
     )
     q = Query(
         datasource="test",
-        timefilter={"times": [numpy.datetime64("2000-01-01T00:00:00"), numpy.datetime64("2001-01-01T00:00:00")]},
+        timefilter={
+            "times": [
+                numpy.datetime64("2000-01-01T00:00:00"),
+                numpy.datetime64("2001-01-01T00:00:00"),
+            ]
+        },
     )
     q = Query(
         datasource="test",
-        timefilter={"times": ["P5D","P2D"]},
+        timefilter={"times": ["P5D", "P2D"]},
     )
     q = Query(
         datasource="test",
-        timefilter={"times": [-numpy.timedelta64(5,"D"), numpy.timedelta64(2,"D")]}
-        )
+        timefilter={"times": [-numpy.timedelta64(5, "D"), numpy.timedelta64(2, "D")]},
+    )
     q = Query(
         datasource="test",
-        timefilter={"times": [-datetime.timedelta(5), -datetime.timedelta(2)]}
-        )
+        timefilter={"times": [-datetime.timedelta(5), -datetime.timedelta(2)]},
+    )
+
+
+def _times(timefilter):
+    """Serialize a query and return the resolved timefilter times."""
+    q = Query(datasource="test", timefilter=timefilter)
+    return json.loads(q.model_dump_json())["timefilter"]["times"]
+
+
+def test_query_timefilter_negative_periods():
+    # ISO8601-2 convention: negative period => before now, positive => after now,
+    # for both timestart and tend. The sign must survive serialization.
+    assert _times({"times": ["P7D", "P1D"]}) == ["P7D", "P1D"]
+    assert _times({"times": ["-P7D", "P1D"]}) == ["-P7D", "P1D"]
+    assert _times({"times": ["-P7D", "-P1D"]}) == ["-P7D", "-P1D"]
+    # period with a time component keeps its sign
+    assert _times({"times": ["-P1DT12H", "PT6H"]}) == ["-P1DT12H", "PT6H"]
+    # negative python timedelta
+    assert _times(
+        {"times": [-datetime.timedelta(days=7), datetime.timedelta(days=2)]}
+    ) == ["-P7D", "P2D"]
+    # negative numpy timedelta64
+    assert _times(
+        {"times": [-numpy.timedelta64(5, "D"), numpy.timedelta64(2, "D")]}
+    ) == ["-P5D", "P2D"]
+
 
 def test_query_aggregate():
     q = Query(
@@ -94,5 +125,5 @@ def test_stage_resp():
         coordmap={"var": "tyx"},
         coordkeys={"var": "tyx"},
         container="dataset",
-        sig="efg"
+        sig="efg",
     )


### PR DESCRIPTION
## Summary

Establishes the ISO8601-2 negative-period convention for the datamesh `timefilter`.

**Convention:** a period in a timefilter resolves relative to the current time — a positive period (e.g. `P7D`) resolves to a time *after* now, a negative period (e.g. `-P7D`) to a time *before* now. This applies equally to `timestart` and `tend`.

## Background

Negative timedeltas already parse (`pandas.Timedelta`) and serialize correctly to ISO8601-2 form (`-P7D`, `-P7DT12H`), but the convention was undocumented and untested, so this change makes it explicit and locks it in.

## Changes (`src/oceanum/datamesh/query.py`)

- Documents the convention on `parse_timedelta`, the `Timedelta` annotated type, the `TimeFilter` class docstring, and the `times` field description.

## Tests

Adds `test_query_timefilter_negative_periods` asserting signed serialization for string periods (`-P7D`, `-P1DT12H`), negative `datetime.timedelta`, and negative `numpy.timedelta64`. Full `tests/test_query.py` passes (8 tests).

## Version

Bumps `oceanum` `1.0.16` → `1.0.17`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)