### PR TITLE
Apply PEP 639 for improved license metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,8 @@ build-backend = "setuptools.build_meta"
 name = "oceanum"
 description = "Library for oceanum.io services"
 readme = "README.rst"
-license = { file = "LICENSE" }
+license = "MIT"
+license-files = ["AUTHORS.rst", "LICENSE"]
 keywords = ["oceanum", "datamesh", "oceanum.io"]
 authors = [
     { name = "Oceanum Developers", email = "developers@oceanum.science" },
@@ -17,7 +18,6 @@ maintainers = [
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: MIT License",
     "Natural Language :: English",
     "Operating System :: OS Independent",
     "Topic :: Scientific/Engineering",


### PR DESCRIPTION
This improves the licence metadata inline with [PEP 639](https://peps.python.org/pep-0639/) and cleans up some deprecation warnings while building, using these changes:

- Use a text SPDX licence identifier instead of a table, which is deprecated
- Remove licence classifier, which is deprecated