### PR TITLE
Use dependency groups (PEP 735)

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,7 +22,7 @@ jobs:
       name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install . 'oceanum[extra,test]'
+        pip install . --group tests
     -
       name: Test
       run: pytest -s -v tests

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -28,14 +28,13 @@ jobs:
       name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install . 'oceanum[extra,test]'
+        pip install . --group dev
     -
       name: Test
       run: pytest -s -v tests
     -
       name: Build package
       run: |
-        pip install build
         python -m build -s
     -
       name: Publish package

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,37 +32,47 @@ dependencies = [
     "aiohttp",
     "click",
     "cftime",
-    "dask",
+    "dask[dataframe,distributed]",
     "decorator",
     "fsspec",
     "geojson-pydantic",
     "geopandas",
     "h5netcdf[h5py]",
+    "msgpack",
     "netcdf4",
     "numpy",
+    "numcodecs",
     "orjson",
     "pandas",
     "platformdirs",
     "pyarrow",
     "pydantic[email]",
+    "python-jsonpath",
+    "requests",
     "shapely",
     "tabulate",
     "xarray",
     "rioxarray",
     "zarr<3",
-    "numcodecs",
-    "dask[dataframe,distributed]",
-    "msgpack",
-    "cftime",
-    "python-jsonpath",
-    "requests"
 ]
 dynamic = ["version"]
 
 [project.optional-dependencies]
-test = ["pytest", "pytest-env", "pytest-asyncio", "python-dotenv",]
-video = ["xarray_video"]
 eidos = ["oceanum.eidos"]
+video = ["xarray_video"]
+
+[dependency-groups]
+dev = [
+    "build",
+    "twine",
+    {include-group = "tests"},
+]
+tests = [
+    "pytest",
+    "pytest-asyncio",
+    "pytest-env",
+    "python-dotenv",
+]
 docs = [
     "autodoc-pydantic",
     "pydata-sphinx-theme",


### PR DESCRIPTION
This PR uses dependency groups from [PEP 735](https://peps.python.org/pep-0735/). Some of the extras (or optional dependencies are revised). Dependency groups are a standard Python feature, and only need a recent version of pip to function. Here are some notes related to this changes:

- Add dependency group "dev" with build and twine packages, as used in ci workflows and in Makefile. The "dev" group is installed by default with (e.g.) `uv sync`.
- Move extra "test" to dependency group "tests" (same name as the directory); this is added to the "dev" group
- Move extra "docs" to dependency group "docs"; this is not added to the "dev" group
- The remaining optional dependencies "video" and "eidos" are kept; note there are references to "extra" that were never defined
- The dependencies list is alpha-sorted, and duplicate items are removed