### PR TITLE
Make Python 3 only non-universal builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
     "Topic :: Scientific/Engineering",
     "Topic :: Scientific/Engineering :: Physics",
     "Topic :: Scientific/Engineering :: Visualization",
+    "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -101,9 +102,6 @@ include = [
   "oceanum.cli.models",
 ]
 exclude = ["tests", "docs"]
-
-[tool.distutils.bdist_wheel]
-universal = true
 
 [tool.pytest.ini_options]
 required_plugins = "pytest-env"


### PR DESCRIPTION
Currently, this package builds "universal" wheels that are designed to work with Python 2 and 3, creating a file `oceanum-1.1.1-py2.py3-none-any.whl`. While building, a warning is shown:
```
running bdist_wheel
/home/mtoews/.cache/uv/builds-v0/.tmp4Y3new/lib/python3.14/site-packages/setuptools/_distutils/cmd.py:119: SetuptoolsDeprecationWarning: bdist_wheel.universal is deprecated
!!

        ********************************************************************************
        With Python 2.7 end-of-life, support for building universal wheels
        (i.e., wheels that support both Python 2 and Python 3)
        is being obviated.
        Please discontinue using this option, or if you still need it,
        file an issue with pypa/setuptools describing your use case.

        This deprecation is overdue, please update your project and remove deprecated
        calls to avoid build errors in the future.
        ********************************************************************************

!!
```
This package should be clearly marked as Python 3 only, not enabling universal wheel builds. The changes in this PR remove this message, and creates `oceanum-1.1.1-py3-none-any.whl`.