### PR TITLE
Validate LevelFilter levels against the filter type

### DIFF
--- a/src/oceanum/datamesh/query.py
+++ b/src/oceanum/datamesh/query.py
@@ -270,6 +270,23 @@ class LevelFilter(BaseModel):
         description="Interpolation method to use for series type level filters",
     )
 
+    @field_validator("levels")
+    @classmethod
+    def validate_levels(cls, v, info):
+        type_ = info.data.get("type")
+        if type_ == LevelFilterType.range:
+            if len(v) != 2:
+                raise ValueError(
+                    f"For LevelFilters of type='range', levels must contain exactly 2 values: [levelstart, levelend], got {len(v)}. "
+                    "To select one or more individual levels, use type='series' instead."
+                )
+        elif type_ in (LevelFilterType.series, LevelFilterType.trajectory):
+            if len(v) < 1:
+                raise ValueError(
+                    f"For LevelFilters of type='{type_.value}', levels must contain at least 1 value"
+                )
+        return v
+
 
 class TimeFilter(BaseModel):
     """TimeFilter class

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -5,9 +5,10 @@ import pytest
 import datetime
 import shapely
 import numpy
+from pydantic import ValidationError
 
 from oceanum.datamesh import Query
-from oceanum.datamesh.query import Stage
+from oceanum.datamesh.query import Stage, LevelFilter
 
 
 def test_query_datasource():
@@ -70,6 +71,52 @@ def test_query_timefilter_negative_periods():
     assert _times(
         {"times": [-numpy.timedelta64(5, "D"), numpy.timedelta64(2, "D")]}
     ) == ["-P5D", "P2D"]
+
+
+def test_query_levelfilter():
+    q = Query(
+        datasource="test",
+        levelfilter={"type": "range", "levels": [0.0, 10.0]},
+    )
+    q = Query(
+        datasource="test",
+        levelfilter={"type": "series", "levels": [0.0]},
+    )
+    q = Query(
+        datasource="test",
+        levelfilter={"type": "series", "levels": [0.0, 10.0, 20.0]},
+    )
+    q = Query(
+        datasource="test",
+        levelfilter={"type": "trajectory", "levels": [0.0, 10.0, 20.0]},
+    )
+
+
+def test_query_levelfilter_range_requires_two_values():
+    with pytest.raises(ValidationError) as excinfo:
+        LevelFilter(type="range", levels=[0.0])
+    message = str(excinfo.value)
+    assert "type='series'" in message
+    assert "exactly 2 values" in message
+
+    with pytest.raises(ValidationError):
+        LevelFilter(type="range", levels=[0.0, 5.0, 10.0])
+
+    # type defaults to 'range', so an omitted type must be caught too - this is
+    # the shape that reached production and crashed the query engine.
+    with pytest.raises(ValidationError) as excinfo:
+        LevelFilter(levels=[0.0])
+    assert "type='series'" in str(excinfo.value)
+
+
+def test_query_levelfilter_series_requires_at_least_one_value():
+    with pytest.raises(ValidationError):
+        LevelFilter(type="series", levels=[])
+
+
+def test_query_levelfilter_trajectory_requires_at_least_one_value():
+    with pytest.raises(ValidationError):
+        LevelFilter(type="trajectory", levels=[])
 
 
 def test_query_aggregate():


### PR DESCRIPTION
## Problem

`LevelFilter` documents its own contract — `type='range'` takes `[levelstart, levelend]`, `type='series'` takes one or more levels — but nothing enforced it. `TimeFilter` has `validate_times` for exactly this, so the asymmetry was the bug.

Because `LevelFilterType` defaults to `range`, a caller writing `levelfilter={"levels": [0]}` — meaning "give me the surface" — was accepted here, then crashed the datamesh query engine:

```
File "/datamesh_query_engine/process/oceanql.py", line 876, in query_dataset_preprocess
    selector[zcoord] = slice(levels[0], levels[1])
IndexError: list index out of range
```

which surfaced to the user as an opaque HTTP 500 plus a bug-report ID (production report `20260728_094408_InternalQueryError_9e128fd3…`).

## Change

`validate_levels` field validator on `LevelFilter`, mirroring `validate_times`:

- `range` → exactly 2 values
- `series` / `trajectory` → at least 1 value

It reads `info.data.get("type")` and no-ops when `type` is absent, so a `type` that failed its own validation doesn't produce a confusing second error.

The message for the production case:

> For LevelFilters of type='range', levels must contain exactly 2 values: [levelstart, levelend], got 1. To select one or more individual levels, use type='series' instead.

This matters beyond the client: the query engine types its FastAPI request bodies with this same `Query` model, so the validator converts that 500 into a 422 at the API boundary for every client, including old ones.

## Tests

Four tests in `tests/test_query.py` following `test_query_timefilter`'s structure: valid range/series/trajectory cases, range with 1 and with 3 values raising, empty series and trajectory raising, and assertions that the message actually names `type='series'`.

Includes the exact production shape — `LevelFilter(levels=[0.0])` with `type` **omitted**, relying on the `range` default — since that is the path that reached production.

`pytest tests/test_query.py` → 15 passed. `black --check` clean.

## Related

Complementary defence-in-depth guard in the query engine: oceanum/datamesh/datamesh-gateway-v1/datamesh-query-engine!59, which raises a 400 with equivalent guidance regardless of which version of this library the image resolves.

No version bump in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoLQVKEp8BjRu7EvVaKETc