### PR TITLE
Serialize the production write tests and report leaked datasources

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -3,6 +3,25 @@ name: Build and test the library
 on:
   push:
 
+# The write tests in tests/test_datamesh_write.py create, read back and delete
+# datasources with fixed ids (test-write-metadata, test-write-dataset-region-
+# chunked, ...) on the production datamesh. Those ids are shared global state,
+# so two runs overlapping anywhere in the repo corrupt each other: one run
+# registers an id the other is about to register ("data source with this id
+# already exists"), or deletes one the other is midway through reading (HTTP
+# 410 "deleted within your session").
+#
+# The group is a constant, deliberately: it must serialize across branches and
+# across workflows, because the contended resource is the production tenant and
+# not the ref. pypi-publish.yml runs the same tests and uses the same group - a
+# release publish fires both workflows at once, which is how two runs collided.
+#
+# cancel-in-progress is false because cancelling a run partway through leaves
+# exactly the orphaned datasources this is trying to avoid. Queue, do not kill.
+concurrency:
+  group: datamesh-prod-write-tests
+  cancel-in-progress: false
+
 jobs:
   build-and-test:
     name: Build and test

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -4,6 +4,13 @@ on:
   release:
     types: [published]
 
+# Same group as build-and-test.yml: this workflow runs the same production
+# write tests, and publishing a release fires both workflows at once. See the
+# comment there for why the group is a constant and why nothing is cancelled.
+concurrency:
+  group: datamesh-prod-write-tests
+  cancel-in-progress: false
+
 jobs:
   pypi-publish:
     name: Upload release to PyPI

--- a/tests/test_datamesh_write.py
+++ b/tests/test_datamesh_write.py
@@ -3,6 +3,8 @@
 
 """Tests for `oceanum` package."""
 import os
+import time
+
 import pytest
 import pandas
 import geopandas
@@ -49,23 +51,72 @@ def geotiff():
     return ds
 
 
+CLEANUP_RETRIES = 3
+CLEANUP_RETRY_WAIT = 2.0
+
+
+def _datasource_exists(conn, datasource_id):
+    """Whether the datasource is still registered.
+
+    Used to tell a failed delete apart from a delete that had nothing to do:
+    several tests below delete their own datasource before returning, so the
+    cleanup delete legitimately fails as not-found. Asking the server is more
+    robust than matching on the error message, which is not a stable contract.
+    """
+    try:
+        conn.get_datasource(datasource_id)
+        return True
+    except Exception:
+        return False
+
+
 @pytest.fixture
 def mark_for_cleanup():
     """Fixture to track and cleanup datasources created during tests."""
     created_datasources = []
-    
+
     def register_datasource(datasource_id, conn):
         created_datasources.append((datasource_id, conn))
         return datasource_id
-    
+
     yield register_datasource
-    
-    # Cleanup all registered datasources
+
+    # Cleanup all registered datasources.
+    #
+    # These ids are fixed and shared with every other run of this suite against
+    # the same datamesh, so a delete that fails silently leaves state that
+    # breaks the *next* run with "data source with this id already exists".
+    # This used to be `except Exception: pass`, which is how
+    # test-write-dataset-region-chunked survived a failed run unnoticed for
+    # hours.
+    #
+    # Retry before reporting: a delete can fail transiently, and the metadata
+    # server is read-replicated, so a single existence check right after a
+    # delete can still see the old record. Only a datasource that is still
+    # there after all attempts counts as leaked.
+    leaked = []
     for datasource_id, conn in created_datasources:
-        try:
-            conn.delete_datasource(datasource_id)
-        except Exception as e:
-            pass
+        last_error = None
+        for attempt in range(CLEANUP_RETRIES):
+            try:
+                conn.delete_datasource(datasource_id)
+                break
+            except Exception as delete_error:
+                last_error = delete_error
+                if not _datasource_exists(conn, datasource_id):
+                    break  # already gone - the test deleted it itself
+                if attempt < CLEANUP_RETRIES - 1:
+                    time.sleep(CLEANUP_RETRY_WAIT)
+        else:
+            leaked.append((datasource_id, last_error))
+
+    if leaked:
+        report = "\n".join(f"  {d}: {e}" for d, e in leaked)
+        raise RuntimeError(
+            "Datasource cleanup failed - these are still registered on the "
+            "datamesh and will break the next run of this suite until they are "
+            f"deleted:\n{report}"
+        )
 
 
 def test_write_dataframe(conn, dataframe, mark_for_cleanup):


### PR DESCRIPTION
Fixes the CI failures on #66, which were not caused by the code in that PR.

## What happened

Two runs overlapped almost entirely:

```
run 30401000640  sha f5b8718  21:31:12 -> 21:40:49
run 30401083343  sha d4a3936  21:32:25 -> 21:40:06
```

A push followed by a force-push 73 seconds later. `build-and-test.yml` triggers on bare `on: push` with no concurrency control, so the second push did not supersede the first — both ran at once.

`tests/test_datamesh_write.py` creates, reads back and deletes datasources with **fixed ids** (`test-write-metadata`, `test-write-dataset-region-chunked`, …) against the **production** datamesh. Those ids are shared global state, so the two runs fought over the same records:

| Symptom | Cause |
|---|---|
| `data source with this id already exists` | other run registered it first |
| `Cannot delete existing datasource` | delete raced |
| `No DataSource matches the given query` on delete | other run had already deleted it |
| HTTP **410** `deleted within your session` mid-read | other run's cleanup deleted it during the read |
| `not found` immediately after a successful write | other run deleted it between write and read |
| `ds.labels[0]` → `IndexError` | other run overwrote the record without labels between write and read |

Nine write tests failed across the two runs, and **five disagreed between the runs on effectively identical code** — `test_write_metadata_with_label` passed in one and failed in the other. That is contention, not a code defect.

## Changes

**1. A concurrency group on both workflows that run the suite.**

The group is a constant, not the usual `${{ github.ref }}`: the contended resource is the production tenant, so it has to serialize across *branches* as well as across *workflows*. `pypi-publish.yml` runs the same `pytest -s -v tests`, and publishing a release fires both workflows simultaneously — that is a second, unrelated way two runs collide, and it has already happened (the `v1.1.2` tag produced two runs in the same minute on 2026-07-24; they passed by luck).

`cancel-in-progress: false` is deliberate: cancelling a run partway through a write test leaves exactly the orphaned datasources this is meant to prevent. Queue, don't kill.

Known trade-off: GitHub keeps only one *pending* run per group, so if runs pile up, an intermediate commit can be superseded and never tested. Given the alternative is corrupting production state, queueing is the right side to err on.

**2. The cleanup fixture no longer swallows failures.**

It was:

```python
except Exception as e:
    pass
```

so a failed delete left a datasource registered, silently. That is how `test-write-dataset-region-chunked` survived a failed run unnoticed for hours — and a leftover breaks the *next* run with "already exists", which is part of what run 30401083343 was already hitting.

It now retries, then raises with the id and the underlying error. Two details worth reviewing:

- **Existence is confirmed against the server, not the error message.** Several tests delete their own datasource before returning, so the cleanup delete legitimately fails as not-found; that is not a leak. Matching on error text would be a guess at an unstable contract.
- **It retries before reporting.** Deletes fail transiently under contention, and the metadata server is read-replicated, so a single existence check straight after a delete can still see the old record. Only something still present after all attempts is called leaked — this avoids turning replica lag into a spurious red build.

Verified against stub connections, all three paths: delete succeeds → clean; delete fails but the datasource is gone → clean (no false leak); delete fails and it is still there → teardown error naming the id.

## Not addressed here

Namespacing the datasource ids per run would make concurrent runs harmless rather than merely serialized, but it trades one problem for another — every failed run would strand a differently-named datasource requiring tracking and manual deletion. Fixed ids stay, on the basis that a known, finite set is what makes leaks trackable at all.

Note that the leftover `test-write-dataset-region-chunked` from the failed runs still needs deleting with the CI org's token; until it is, a run may fail on it — and with this change, say so clearly instead of hiding it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoLQVKEp8BjRu7EvVaKETc