### PR TITLE
Harden Session.close(): retry the DELETE so failed writes release their lock

### DIFF
--- a/src/oceanum/datamesh/session.py
+++ b/src/oceanum/datamesh/session.py
@@ -5,6 +5,11 @@ from .exceptions import DatameshConnectError, DatameshSessionError
 from .utils import retried_request, HTTPSession
 import atexit
 import os
+import logging
+import time
+
+
+logger = logging.getLogger(__name__)
 
 
 class Session(BaseModel):
@@ -153,19 +158,44 @@ class Session(BaseModel):
             atexit.unregister(self.close)
         except:
             pass
-        res = retried_request(
-            f"{self._connection._gateway}/session/{self.id}",
-            method="DELETE",
-            params={"finalise_write": finalise_write},
-            headers=self.header,
-            http_session=self._connection.http_session,
-        )
-        if res.status_code != 204:
-            if finalise_write:
-                raise DatameshConnectError(
-                    "Failed to finalise write with error: " + res.text
+
+        # Retry DELETE on non-204 responses with exponential backoff
+        max_attempts = 4  # initial + 3 retries
+        backoff_delays = [1, 2, 4]  # seconds
+
+        for attempt in range(max_attempts):
+            res = retried_request(
+                f"{self._connection._gateway}/session/{self.id}",
+                method="DELETE",
+                params={"finalise_write": finalise_write},
+                headers=self.header,
+                http_session=self._connection.http_session,
+            )
+
+            if res.status_code == 204:
+                return
+
+            # Treat 404/410 as success (session already closed)
+            if res.status_code in (404, 410):
+                return
+
+            # If this was the last attempt, handle the error
+            if attempt == max_attempts - 1:
+                if finalise_write:
+                    raise DatameshConnectError(
+                        "Failed to finalise write with error: " + res.text
+                    )
+                # Log warning instead of raising for finalise_write=False
+                # (we're in __exit__ and raising would mask the original error)
+                logger.warning(
+                    f"Failed to close session {self.id} after {max_attempts} attempts. "
+                    f"Status code: {res.status_code}. Response: {res.text}. "
+                    f"Session may block writes to its datasource until it expires."
                 )
-            print("Failed to close session with error: " + res.text)
+                return
+
+            # Not the last attempt and status != 204/404/410, so retry with backoff
+            time.sleep(backoff_delays[attempt])
 
     def __enter__(self):
         return self

--- a/tests/test_session_close_retry.py
+++ b/tests/test_session_close_retry.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""Tests for Session.close() retry logic."""
+
+import pytest
+from unittest.mock import Mock, patch, MagicMock
+from datetime import datetime
+
+from oceanum.datamesh.session import Session
+from oceanum.datamesh.exceptions import DatameshConnectError
+
+
+@pytest.fixture
+def mock_connection():
+    """Create a mock connection object."""
+    conn = Mock()
+    conn._gateway = "http://test-gateway"
+    conn.http_session = Mock()
+    return conn
+
+
+@pytest.fixture
+def test_session(mock_connection):
+    """Create a test session."""
+    session = Session(
+        id="test-session-123",
+        user="testuser",
+        creation_time=datetime.now(),
+        end_time=datetime.now(),
+        write=True,
+        allow_multiwrite=False,
+        verified=False,
+    )
+    session._connection = mock_connection
+    return session
+
+
+class TestSessionCloseRetry:
+    """Test suite for Session.close() retry behavior."""
+
+    def test_close_204_first_try_no_retry(self, test_session):
+        """Test that 204 response on first attempt requires no retry."""
+        mock_response = Mock()
+        mock_response.status_code = 204
+
+        with patch("oceanum.datamesh.session.retried_request") as mock_request:
+            with patch("oceanum.datamesh.session.time.sleep") as mock_sleep:
+                mock_request.return_value = mock_response
+                test_session.close(finalise_write=False)
+
+                # Should only be called once
+                assert mock_request.call_count == 1
+                # No sleep should be called
+                mock_sleep.assert_not_called()
+
+    def test_close_500_then_204_with_retry(self, test_session):
+        """Test that 500 error triggers retry, and 204 succeeds on retry."""
+        mock_response_500 = Mock()
+        mock_response_500.status_code = 500
+        mock_response_500.text = "Internal Server Error"
+
+        mock_response_204 = Mock()
+        mock_response_204.status_code = 204
+
+        with patch("oceanum.datamesh.session.retried_request") as mock_request:
+            with patch("oceanum.datamesh.session.time.sleep") as mock_sleep:
+                # First call returns 500, second call returns 204
+                mock_request.side_effect = [mock_response_500, mock_response_204]
+
+                test_session.close(finalise_write=False)
+
+                # Should be called twice
+                assert mock_request.call_count == 2
+                # Sleep should be called once with 1 second delay
+                mock_sleep.assert_called_once_with(1)
+
+    def test_close_all_non_204_finalise_write_false_logs_warning(
+        self, test_session, caplog
+    ):
+        """Test that all non-204 responses log warning when finalise_write=False."""
+        mock_response = Mock()
+        mock_response.status_code = 500
+        mock_response.text = "Internal Server Error"
+
+        with patch("oceanum.datamesh.session.retried_request") as mock_request:
+            with patch("oceanum.datamesh.session.time.sleep"):
+                mock_request.return_value = mock_response
+
+                # Should not raise exception
+                test_session.close(finalise_write=False)
+
+                # Should log a warning
+                assert len(caplog.records) == 1
+                assert caplog.records[0].levelname == "WARNING"
+                assert "Failed to close session" in caplog.text
+                assert "test-session-123" in caplog.text
+                assert "500" in caplog.text
+
+    def test_close_all_non_204_finalise_write_true_raises(self, test_session):
+        """Test that all non-204 responses raise when finalise_write=True."""
+        mock_response = Mock()
+        mock_response.status_code = 500
+        mock_response.text = "Internal Server Error"
+
+        with patch("oceanum.datamesh.session.retried_request") as mock_request:
+            with patch("oceanum.datamesh.session.time.sleep"):
+                mock_request.return_value = mock_response
+
+                # Should raise exception
+                with pytest.raises(DatameshConnectError) as exc_info:
+                    test_session.close(finalise_write=True)
+
+                assert "Failed to finalise write" in str(exc_info.value)
+                assert "Internal Server Error" in str(exc_info.value)
+
+    def test_close_404_treated_as_success(self, test_session):
+        """Test that 404 response is treated as success."""
+        mock_response = Mock()
+        mock_response.status_code = 404
+        mock_response.text = "Not Found"
+
+        with patch("oceanum.datamesh.session.retried_request") as mock_request:
+            with patch("oceanum.datamesh.session.time.sleep") as mock_sleep:
+                mock_request.return_value = mock_response
+
+                # Should not raise exception and not log warning
+                test_session.close(finalise_write=False)
+
+                # Should only be called once
+                assert mock_request.call_count == 1
+                # No sleep should be called
+                mock_sleep.assert_not_called()
+
+    def test_close_410_treated_as_success(self, test_session):
+        """Test that 410 Gone response is treated as success."""
+        mock_response = Mock()
+        mock_response.status_code = 410
+        mock_response.text = "Gone"
+
+        with patch("oceanum.datamesh.session.retried_request") as mock_request:
+            with patch("oceanum.datamesh.session.time.sleep") as mock_sleep:
+                mock_request.return_value = mock_response
+
+                # Should not raise exception
+                test_session.close(finalise_write=False)
+
+                # Should only be called once
+                assert mock_request.call_count == 1
+                # No sleep should be called
+                mock_sleep.assert_not_called()
+
+    def test_close_retries_with_exponential_backoff(self, test_session):
+        """Test that retries use exponential backoff (1s, 2s, 4s)."""
+        mock_response_500 = Mock()
+        mock_response_500.status_code = 500
+        mock_response_500.text = "Server Error"
+
+        with patch("oceanum.datamesh.session.retried_request") as mock_request:
+            with patch("oceanum.datamesh.session.time.sleep") as mock_sleep:
+                # Return 500 for all 4 attempts (initial + 3 retries)
+                mock_request.return_value = mock_response_500
+
+                test_session.close(finalise_write=False)
+
+                # Should be called 4 times
+                assert mock_request.call_count == 4
+                # Sleep should be called 3 times with correct delays
+                assert mock_sleep.call_count == 3
+                sleep_calls = [call[0][0] for call in mock_sleep.call_args_list]
+                assert sleep_calls == [1, 2, 4]
+
+    def test_close_503_then_204_with_backoff(self, test_session):
+        """Test retry sequence with 503 then 204 success."""
+        mock_response_503 = Mock()
+        mock_response_503.status_code = 503
+        mock_response_503.text = "Service Unavailable"
+
+        mock_response_204 = Mock()
+        mock_response_204.status_code = 204
+
+        with patch("oceanum.datamesh.session.retried_request") as mock_request:
+            with patch("oceanum.datamesh.session.time.sleep") as mock_sleep:
+                # First call 503, second call 204
+                mock_request.side_effect = [mock_response_503, mock_response_204]
+
+                test_session.close(finalise_write=False)
+
+                # Should be called twice
+                assert mock_request.call_count == 2
+                # Sleep should be called once with 1 second
+                mock_sleep.assert_called_once_with(1)
+
+    def test_close_retries_exhaust_then_log_with_response_text(
+        self, test_session, caplog
+    ):
+        """Test that final warning includes response text."""
+        mock_response = Mock()
+        mock_response.status_code = 502
+        mock_response.text = "Bad Gateway - upstream service down"
+
+        with patch("oceanum.datamesh.session.retried_request") as mock_request:
+            with patch("oceanum.datamesh.session.time.sleep"):
+                mock_request.return_value = mock_response
+
+                test_session.close(finalise_write=False)
+
+                assert len(caplog.records) == 1
+                assert "Bad Gateway - upstream service down" in caplog.text
+
+    def test_close_atexit_unregistration_before_retry_logic(self, test_session):
+        """Test that atexit unregistration happens before retry logic."""
+        mock_response = Mock()
+        mock_response.status_code = 204
+
+        with patch("oceanum.datamesh.session.retried_request") as mock_request:
+            with patch("atexit.unregister") as mock_unregister:
+                mock_request.return_value = mock_response
+
+                test_session.close(finalise_write=False)
+
+                # atexit.unregister should have been called
+                mock_unregister.assert_called_once_with(test_session.close)
+
+    def test_close_atexit_unregistration_handles_exception(self, test_session):
+        """Test that atexit.unregister exception is silently ignored."""
+        mock_response = Mock()
+        mock_response.status_code = 204
+
+        with patch("oceanum.datamesh.session.retried_request") as mock_request:
+            with patch("atexit.unregister") as mock_unregister:
+                # Make atexit.unregister raise an exception
+                mock_unregister.side_effect = ValueError("Not registered")
+                mock_request.return_value = mock_response
+
+                # Should not raise exception
+                test_session.close(finalise_write=False)
+
+                # retried_request should still be called
+                assert mock_request.call_count == 1


### PR DESCRIPTION
## Context

When a datamesh write fails, the client's `Session.__exit__` calls `close(finalise_write=False)` to release the server-side write-session lock. Today a non-204 response to that DELETE is retried zero times and reported only via `print(...)` — the abandoned session then blocks **every other writer** of that datasource for up to the session TTL (1 hour). This was a contributing factor in the 2026-07-29 `wrl-metocean-forecast-ec` write-livelock incident (rotating stale writer locks across retries). The transport layer (`retried_request`) retries connection errors and 502s, but non-204 *responses* were returned as-is.

## Changes (`src/oceanum/datamesh/session.py`)

- `close()` now retries the DELETE up to 3 more times (1s/2s/4s backoff) on any status other than 204
- 404/410 are treated as success — the session is already gone, which is the outcome we want
- `finalise_write=True`: unchanged contract — still raises `DatameshConnectError` after exhaustion
- `finalise_write=False`: still never raises (it runs inside `__exit__` during exception handling, where raising would mask the original write error) — but the silent `print` is now a proper `logging` warning including the session id, final status, response text, and the consequence ("session may block writes to its datasource until it expires")
- `atexit` handling unchanged; `retried_request` untouched; no version bump

## Tests

`tests/test_session_close_retry.py` — 11 mocked unit tests, all passing: no-retry on first 204; 500→204 and 503→204 recovery; exhaustion with warning (caplog) vs exhaustion with raise; 404/410 short-circuit; exact backoff sequence; atexit ordering.

## Reviewer note

Retrying with `finalise_write=True` is new behaviour (previously one attempt then raise). Retries are safe because the server's finalise path tolerates re-runs ("commit: no changes" is handled), but a 404 on a finalise *retry* now maps to success — in a rare partial-failure ordering (server deleted the session record but failed the finalise) this could mask an unfinalised write. We kept it as-is because erring toward releasing the lock is the point of this change, but flagging for a considered opinion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013oL8SSk48bG2GRp3oWdrBX